### PR TITLE
Add MetaTrader 5 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "mql-zmq"]
 	path = mql-zmq
-	url = https://github.com/dingmaotu/mql-zmq.git
+	url = https://github.com/danmigdev/mql-zmq.git
+	branch = fix/mql5_compatibility

--- a/README.md
+++ b/README.md
@@ -1,29 +1,63 @@
-# MetaTrader 4 Server
-Provides a remote interface and high-level API for MetaTrader 4 via ZeroMQ sockets.\
+# MetaTrader 4/5 Server
+Provides a remote interface and high-level API for MetaTrader 4 and MetaTrader 5 via ZeroMQ sockets.\
 See [API](docs/api.md) for supported operations.
 
 ![Diagram 1](diagram_1.png)
 
-## Installation
-1. Copy [metatrader4](metatrader4) into your MetaTrader 4 profile directory, merging the 
+## Supported Platforms
+
+| Platform | Status | Directory |
+|----------|--------|-----------|
+| MetaTrader 4 | Stable | [metatrader4/](metatrader4/) |
+| MetaTrader 5 | Stable | [metatrader5/](metatrader5/) |
+
+## MetaTrader 4 Installation
+
+1. Copy [metatrader4](metatrader4) into your MetaTrader 4 profile directory, merging the
 folder contents.
-1. Copy [mql-zmq/Include/](https://github.com/dingmaotu/mql-zmq/tree/f9bf8d94a34194a4fe79ae625779226900fe8657/Include) into the `MQL4/Include` subdirectory of your MetaTrader 4 profile directory, merging the 
+1. Copy [mql-zmq/Include/](https://github.com/danmigdev/mql-zmq/tree/fix/mql5_compatibility/Include) into the `MQL4/Include` subdirectory of your MetaTrader 4 profile directory, merging the
 folder contents.
-1. Copy [mql-zmq/Library/MT4/](https://github.com/dingmaotu/mql-zmq/tree/f9bf8d94a34194a4fe79ae625779226900fe8657/Library/MT4) into the `MQL4/Libraries` subdirectory of your MetaTrader 4 profile directory, merging the 
+1. Copy [mql-zmq/Library/MT4/](https://github.com/danmigdev/mql-zmq/tree/fix/mql5_compatibility/Library/MT4) into the `MQL4/Libraries` subdirectory of your MetaTrader 4 profile directory, merging the
 folder contents.
 1. Launch MetaEditor, open `MQL4/Scripts/ZeroMQ_Server.mq4` in your MetaTrader 4 profile directory and compile it.
-1. Start MetaTrader 4 and add the `ZeroMQ Server` script to any chart (chart symbol does not matter).  The server begins 
+1. Start MetaTrader 4 and add the `ZeroMQ Server` script to any chart (chart symbol does not matter). The server begins
 listening for client requests and responds synchronously.
 
+## MetaTrader 5 Installation
+
+1. Copy [metatrader5/MQL5](metatrader5/MQL5) into your MetaTrader 5 profile directory, merging the folder contents.
+1. Copy [mql-zmq/Include/](https://github.com/danmigdev/mql-zmq/tree/fix/mql5_compatibility/Include) into the `MQL5/Include` subdirectory of your MetaTrader 5 profile directory, merging the folder contents.
+1. Copy [mql-zmq/Library/MT5/](https://github.com/danmigdev/mql-zmq/tree/fix/mql5_compatibility/Library/MT5) into the `MQL5/Libraries` subdirectory of your MetaTrader 5 profile directory, merging the folder contents.
+1. Launch MetaEditor, open and compile:
+   - `MQL5/Experts/ZeroMQ_Server_EA.mq5`
+   - `MQL5/Experts/ZeroMQ_Monitor_EA.mq5` (optional watchdog)
+1. Start MetaTrader 5 and add `ZeroMQ_Server_EA` to any chart.
+
+> **Note:** For MT5 detailed setup instructions, see [metatrader5/MQL5/Experts/README.md](metatrader5/MQL5/Experts/README.md)
+
+### MT5 Features
+
+- **Expert Advisor**: Runs as EA instead of script, supports templates for auto-restart
+- **Watchdog Monitor**: `ZeroMQ_Monitor_EA` monitors server health and auto-restarts if unresponsive
+- **Long Ticket Support**: MT5 uses `long` (64-bit) ticket numbers
+
+### MT5 Library Compatibility
+
+MT5 requires the `fix/mql5_compatibility` branch of mql-zmq to fix `char[]/uchar[]` type conversion errors:
+
+```
+https://github.com/danmigdev/mql-zmq/tree/fix/mql5_compatibility
+```
+
 ## Configuration
-The default listening port is `TCP/28282` but is configurable in the script parameters popup in the MetaTrader terminal,
-along with other parameters such as socket timeouts.  If Windows Defender Firewall is running, you must forward the port.
+The default listening port is `TCP/28282` but is configurable in the script/EA parameters popup in the MetaTrader terminal,
+along with other parameters such as socket timeouts. If Windows Defender Firewall is running, you must forward the port.
 
 ## Usage
 Typical client usage:
 
 1. Create a ZeroMQ context and a `REQ` socket with appropriate send/receive timeouts and options.
-1. Connect the `REQ` socket to the server's `REP` socket. 
+1. Connect the `REQ` socket to the server's `REP` socket.
 1. Perform the following sequence any number of times:
     1. Construct an [API](docs/api.md) request.
     1. Send the request to the `REQ` socket.
@@ -31,13 +65,34 @@ Typical client usage:
 1. Close the socket connection and destroy the ZeroMQ context.
 
 It is recommended to use one of the following client libraries to abstract away these details:
-- [Python client](https://github.com/CoeJoder/metatrader4-client-python)
-- [Java client](https://github.com/CoeJoder/metatrader4-client-java)
+
+| Client | MT4 | MT5 | Repository |
+|--------|-----|-----|------------|
+| Python | Yes | Yes | [metatrader4-client-python](https://github.com/CoeJoder/metatrader4-client-python) |
+| Java   | Yes | Yes | [metatrader4-client-java](https://github.com/danmigdev/metatrader4-client-java) |
+
+### Java Client Example
+
+```java
+// MT4 Client
+try (MT4Client client = new MT4Client("tcp://127.0.0.1:28282")) {
+    Account account = client.getAccount();
+    System.out.println("Balance: " + account.getBalance());
+}
+
+// MT5 Client (supports long ticket numbers)
+try (MT5Client client = new MT5Client("tcp://127.0.0.1:28282")) {
+    List<MT5Order> orders = client.getOrders();
+    for (MT5Order order : orders) {
+        System.out.println("Ticket: " + order.getTicket()); // long type
+    }
+}
+```
 
 ## Limitations
 The `REQ-REP` socket connection enforces a strict request-response cycle and may deadlock if connection is lost.
 The client libraries use `ZMQ_REQ_RELAXED` and `ZMQ_REQ_CORRELATE` socket options to prevent this in most cases.
-If a response is dropped, the client may want to catch the exception and check whether or not the operation was 
+If a response is dropped, the client may want to catch the exception and check whether or not the operation was
 successful.
 
 ## Development

--- a/metatrader5/MQL5/Experts/README.md
+++ b/metatrader5/MQL5/Experts/README.md
@@ -1,0 +1,198 @@
+# ZeroMQ Server and Monitor for MetaTrader 5
+
+This folder contains two Expert Advisors (EA) for managing ZeroMQ communication with MetaTrader 5.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `ZeroMQ_Server_EA.mq5` | ZeroMQ server to receive remote commands |
+| `ZeroMQ_Monitor_EA.mq5` | Watchdog to monitor and restart the server |
+
+## Installation
+
+1. Copy the `.mq5` files to the `MQL5/Experts/` folder of your MT5 terminal
+2. Copy the `Include/Zmq/` folder to `MQL5/Include/`
+3. Compile both EAs in MetaEditor
+
+## ZeroMQ_Server_EA Configuration
+
+### Input Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `SCRIPT_NAME` | ZeroMQ_Server_EA | Server identifier name |
+| `ADDRESS` | tcp://*:28282 | Listening address and port |
+| `REQUEST_POLLING_INTERVAL` | 10 | Polling interval in milliseconds |
+| `RESPONSE_TIMEOUT` | 300000 | Response timeout (5 minutes) |
+| `MIN_POINT_DISTANCE` | 3 | Minimum distance in points |
+| `VERBOSE` | false | Enable detailed logging |
+
+### Setup
+
+1. Open a chart (e.g., EURUSD)
+2. Drag `ZeroMQ_Server_EA` onto the chart
+3. Enable "Allow DLL imports" in options
+4. Click OK
+
+### Creating a Template for Auto-Restart
+
+1. Configure the server EA on the chart
+2. Go to `Chart > Templates > Save Template`
+3. Save as `ZeroMQ_Server_EA.tpl`
+
+## ZeroMQ_Monitor_EA Configuration
+
+The Monitor EA checks that the Server is active and automatically restarts it if unresponsive.
+
+### Input Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `ENABLED` | true | Enable/disable the monitor |
+| `TIMEOUT_SECONDS` | 30 | Timeout before restart |
+| `CHECK_INTERVAL_SECONDS` | 15 | Check interval in seconds |
+| `TEMPLATE_NAME` | ZeroMQ_Server_EA | Template name for restart |
+| `SERVER_CHART_SYMBOL` | "" | Server chart symbol (empty = same symbol) |
+| `SERVER_CHART_ID` | 0 | Specific chart ID (0 = auto-detect) |
+
+### Recommended Setup (Two Charts)
+
+Using two separate charts allows the Monitor to restart the Server without removing itself.
+
+#### Step 1: Setup the Server Chart
+
+1. Open MetaTrader 5
+2. Go to `File > New Chart > EURUSD` (or any symbol)
+3. In the Navigator panel (Ctrl+N), expand `Expert Advisors`
+4. Drag `ZeroMQ_Server_EA` onto the chart
+5. In the popup dialog:
+   - Go to `Dependencies` tab
+   - Check "Allow DLL imports"
+   - Click OK
+6. Verify in the Experts tab (Ctrl+T) that the server started:
+   ```
+   ZeroMQ Server EA v3.0 - Watchdog heartbeat enabled
+   Listening for requests on tcp://*:28282
+   ```
+
+#### Step 2: Create the Restart Template
+
+1. With the Server EA running on the chart
+2. Go to `Chart > Templates > Save Template...`
+3. Save as exactly: `ZeroMQ_Server_EA.tpl`
+4. The template is saved in `MQL5/Profiles/Templates/`
+
+#### Step 3: Find the Server Chart ID
+
+The Chart ID is a unique number that identifies each chart window. You need this to tell the Monitor which chart to restart.
+
+**Method 1 - From Server Logs:**
+1. Look at the Experts tab when the Server starts
+2. Find the log line containing the chart ID:
+   ```
+   [DEBUG] This chart ID: 132456789012345678
+   ```
+
+**Method 2 - From Monitor Auto-Detection:**
+1. Start the Monitor EA (next step)
+2. Look at the Experts tab for:
+   ```
+   [DEBUG] Found chart 132456789012345678 symbol=EURUSD
+   [INFO] To use a specific chart, set SERVER_CHART_ID = 132456789012345678
+   ```
+3. Copy this number for the next step
+
+**Method 3 - Using a Script:**
+1. Create a new script in MetaEditor with:
+   ```mql5
+   void OnStart() {
+       Print("This chart ID: ", ChartID());
+   }
+   ```
+2. Run it on the Server chart
+3. Check the Experts tab for the ID
+
+#### Step 4: Setup the Monitor Chart
+
+1. Go to `File > New Chart > EURUSD` (same symbol as Server)
+2. You now have two EURUSD charts open
+3. Drag `ZeroMQ_Monitor_EA` onto the NEW chart (not the Server chart)
+4. In the popup dialog:
+   - Set `SERVER_CHART_ID` = the ID from Step 3 (e.g., `132456789012345678`)
+   - Adjust `TIMEOUT_SECONDS` if needed (default 30)
+   - Click OK
+5. Verify in Experts tab:
+   ```
+   ZeroMQ Monitor v1.4 initialized
+     - Server chart ID: 132456789012345678 (EURUSD)
+   ```
+
+#### Step 5: Test the Setup
+
+1. Stop the Server EA manually (right-click > Remove EA)
+2. Wait for `TIMEOUT_SECONDS` (default 30 seconds)
+3. The Monitor should detect the timeout and restart:
+   ```
+   [WARNING] ZeroMQ Server heartbeat not found - server may not be running
+   [ACTION] Attempting to restart ZeroMQ Server...
+   [OK] Template 'ZeroMQ_Server_EA.tpl' applied
+   ```
+
+### Temporarily Disable
+
+To disable the monitor without removing it:
+1. Right-click on EA > Properties
+2. Set `ENABLED = false`
+3. Click OK
+
+## How It Works
+
+```
++-------------------+        +-------------------+
+|  ZeroMQ_Server_EA |        | ZeroMQ_Monitor_EA |
++-------------------+        +-------------------+
+         |                            |
+         v                            v
+  Updates GlobalVariable       Reads GlobalVariable
+  "ZeroMQ_Server_LastResponse" every CHECK_INTERVAL
+         |                            |
+         |                   If timeout > TIMEOUT_SECONDS
+         |                            |
+         |                   Applies template to
+         |                   restart the server
+         v                            v
++-------------------------------------------+
+|           GlobalVariables MT5             |
++-------------------------------------------+
+```
+
+## Troubleshooting
+
+### Server won't start
+- Verify "Allow DLL imports" is enabled
+- Check that `libzmq.dll` is in the `Libraries/` folder
+- Check logs in the "Experts" tab
+
+### Monitor can't find the server
+- Set `SERVER_CHART_ID` manually
+- Verify both EAs are on the same symbol
+
+### Auto-restart doesn't work
+- Verify the template `ZeroMQ_Server_EA.tpl` exists
+- Template must be in `MQL5/Profiles/Templates/`
+
+## Java Connection
+
+```java
+try (MT5Client client = new MT5Client("tcp://127.0.0.1:28282")) {
+    Account account = client.getAccount();
+    System.out.println("Balance: " + account.getBalance());
+}
+```
+
+## Requirements
+
+- MetaTrader 5 Build 3000+
+- mql-zmq library (branch `fix/mql5_compatibility`)
+- Java 21+ for the client

--- a/metatrader5/MQL5/Experts/ZeroMQ_Monitor_EA.mq5
+++ b/metatrader5/MQL5/Experts/ZeroMQ_Monitor_EA.mq5
@@ -1,0 +1,180 @@
+//+------------------------------------------------------------------+
+//|                                              ZeroMQ_Monitor.mq5  |
+//|                        Copyright 2025, danmig                     |
+//|                    Watchdog EA for ZeroMQ_Server script           |
+//+------------------------------------------------------------------+
+#property copyright "Copyright 2025, danmig"
+#property link      ""
+#property version   "1.4"
+#property description "Monitors ZeroMQ_Server via GlobalVariable heartbeat and restarts if unresponsive"
+
+// Input parameters
+input bool   ENABLED = true;               // Enable monitor (false = disabled without removing)
+input int    TIMEOUT_SECONDS = 30;         // Timeout in seconds (default 30 seconds)
+input int    CHECK_INTERVAL_SECONDS = 15;  // Check interval in seconds
+input string TEMPLATE_NAME = "ZeroMQ_Server_EA";  // Template name to apply for restart
+input string SERVER_CHART_SYMBOL = "";     // Symbol of chart running ZeroMQ_Server (empty = same as this chart)
+input long   SERVER_CHART_ID = 0;          // Specific chart ID for ZeroMQ_Server (0 = auto-detect from logs)
+
+// Heartbeat global variable name (must match ZeroMQ_Server.mq5)
+const string HEARTBEAT_GV_NAME = "ZeroMQ_Server_LastResponse";
+
+// Chart ID where ZeroMQ_Server runs
+long serverChartId = 0;
+
+//+------------------------------------------------------------------+
+//| Expert initialization function                                     |
+//+------------------------------------------------------------------+
+int OnInit() {
+    // Check if monitor is disabled
+    if (!ENABLED) {
+        Print("ZeroMQ Monitor v1.4 - DISABLED");
+        return(INIT_SUCCEEDED);
+    }
+
+    // Find or validate server chart
+    if (!FindServerChart()) {
+        Print("[ERROR] Could not find server chart. Check SERVER_CHART_SYMBOL parameter.");
+        return(INIT_FAILED);
+    }
+
+    // Set timer for periodic checks
+    EventSetTimer(CHECK_INTERVAL_SECONDS);
+
+    Print("ZeroMQ Monitor v1.4 initialized");
+    Print("  - Timeout: ", TIMEOUT_SECONDS, " seconds");
+    Print("  - Check interval: ", CHECK_INTERVAL_SECONDS, " seconds");
+    Print("  - Restart template: ", TEMPLATE_NAME);
+    Print("  - Server chart ID: ", serverChartId, " (", ChartSymbol(serverChartId), ")");
+
+    // Initial check
+    CheckServerStatus();
+
+    return(INIT_SUCCEEDED);
+}
+
+//+------------------------------------------------------------------+
+//| Find the chart where ZeroMQ_Server should run                      |
+//+------------------------------------------------------------------+
+bool FindServerChart() {
+    // If specific chart ID is provided, use it directly
+    if (SERVER_CHART_ID > 0) {
+        // Validate that the chart exists
+        if (ChartSymbol(SERVER_CHART_ID) != "") {
+            serverChartId = SERVER_CHART_ID;
+            Print("[OK] Using specified server chart ID: ", serverChartId, " (", ChartSymbol(serverChartId), ")");
+            return true;
+        } else {
+            Print("[ERROR] Specified SERVER_CHART_ID ", SERVER_CHART_ID, " does not exist!");
+            return false;
+        }
+    }
+
+    // Auto-detect: find a different chart with target symbol
+    string targetSymbol = SERVER_CHART_SYMBOL;
+    if (targetSymbol == "") {
+        targetSymbol = Symbol();
+    }
+
+    Print("[DEBUG] Auto-detecting chart with symbol: ", targetSymbol);
+    Print("[DEBUG] This chart ID: ", ChartID());
+
+    long chartId = ChartFirst();
+    long thisChartId = ChartID();
+
+    while (chartId >= 0) {
+        Print("[DEBUG] Found chart ", chartId, " symbol=", ChartSymbol(chartId));
+
+        if (chartId != thisChartId && ChartSymbol(chartId) == targetSymbol) {
+            serverChartId = chartId;
+            Print("[DEBUG] Auto-selected server chart: ", serverChartId);
+            Print("[INFO] To use a specific chart, set SERVER_CHART_ID = ", serverChartId);
+            return true;
+        }
+        chartId = ChartNext(chartId);
+    }
+
+    // If no other chart found, warn but allow using same chart
+    Print("[WARNING] No separate chart found for ", targetSymbol, ". Using same chart (Monitor will be removed on restart).");
+    serverChartId = thisChartId;
+    return true;
+}
+
+//+------------------------------------------------------------------+
+//| Expert deinitialization function                                   |
+//+------------------------------------------------------------------+
+void OnDeinit(const int reason) {
+    EventKillTimer();
+    Print("ZeroMQ Monitor stopped");
+}
+
+//+------------------------------------------------------------------+
+//| Timer function - called every CHECK_INTERVAL_SECONDS               |
+//+------------------------------------------------------------------+
+void OnTimer() {
+    if (!ENABLED) return;
+    CheckServerStatus();
+}
+
+//+------------------------------------------------------------------+
+//| Check if ZeroMQ Server is responsive                               |
+//| Reads heartbeat from GlobalVariable updated after each response    |
+//+------------------------------------------------------------------+
+void CheckServerStatus() {
+    // Check if heartbeat global variable exists
+    if (!GlobalVariableCheck(HEARTBEAT_GV_NAME)) {
+        Print("[WARNING] ZeroMQ Server heartbeat not found - server may not be running");
+        RestartServer();
+        return;
+    }
+
+    // Get last successful response timestamp
+    datetime lastResponse = (datetime)GlobalVariableGet(HEARTBEAT_GV_NAME);
+    datetime now = TimeCurrent();
+    int elapsedSeconds = (int)(now - lastResponse);
+
+    // Check if timeout exceeded
+    if (elapsedSeconds > TIMEOUT_SECONDS) {
+        Print("[WARNING] ZeroMQ Server no successful response for ", elapsedSeconds, " seconds (timeout: ", TIMEOUT_SECONDS, ")");
+        Print("  - Last response: ", TimeToString(lastResponse, TIME_DATE|TIME_SECONDS));
+        Print("  - Current time: ", TimeToString(now, TIME_DATE|TIME_SECONDS));
+        RestartServer();
+    } else {
+        // Server is responsive
+        Print("[OK] ZeroMQ Server OK - last response ", elapsedSeconds, " seconds ago");
+    }
+}
+
+//+------------------------------------------------------------------+
+//| Restart the ZeroMQ Server by applying template                     |
+//+------------------------------------------------------------------+
+void RestartServer() {
+    Print("[ACTION] Attempting to restart ZeroMQ Server on chart ", serverChartId, "...");
+
+    // Clear the old heartbeat to avoid immediate re-trigger
+    GlobalVariableDel(HEARTBEAT_GV_NAME);
+
+    // Apply template to the SERVER chart (not this chart)
+    // The template must be saved with the script already running
+    string templateFile = TEMPLATE_NAME + ".tpl";
+
+    if (ChartApplyTemplate(serverChartId, templateFile)) {
+        Print("[OK] Template '", templateFile, "' applied to chart ", serverChartId);
+        Print("[INFO] ZeroMQ Server should restart automatically");
+    } else {
+        int err = GetLastError();
+        Print("[ERROR] Failed to apply template '", templateFile, "' to chart ", serverChartId, ". Error: ", err);
+        Print("[INFO] Please ensure template exists in MQL5/Profiles/Templates/");
+
+        // Alternative: Alert user to manually restart
+        Alert("ZeroMQ Server is unresponsive! Please restart manually.");
+    }
+}
+
+//+------------------------------------------------------------------+
+//| Tick function (not used but required)                              |
+//+------------------------------------------------------------------+
+void OnTick() {
+    // Not used - we rely on timer events
+}
+//+------------------------------------------------------------------+

--- a/metatrader5/MQL5/Experts/ZeroMQ_Server_EA.mq5
+++ b/metatrader5/MQL5/Experts/ZeroMQ_Server_EA.mq5
@@ -1,0 +1,1142 @@
+//+------------------------------------------------------------------+
+//|                                            ZeroMQ_Server_EA.mq5  |
+//|  An endpoint for remote control of MetaTrader 5 via ZeroMQ       |
+//|  EA version - can be saved in templates for auto-restart         |
+//+------------------------------------------------------------------+
+#property description   "An endpoint for remote control of MetaTrader 5 via ZeroMQ sockets."
+#property copyright     "Copyright 2020-2025, CoeJoder - MQL5 Port"
+#property link          "https://github.com/CoeJoder/metatrader4-server"
+#property version       "3.0"
+
+// see: https://github.com/dingmaotu/mql-zmq
+#include <Zmq/Zmq.mqh>
+// see: https://www.mql5.com/en/code/13663
+#include <JAson.mqh>
+#include <Trade/Trade.mqh>
+
+// MQL4 compatibility - define missing error code
+#define ERR_HISTORY_WILL_UPDATED 4066
+
+// input parameters
+input string SCRIPT_NAME = "ZeroMQ_Server_EA";
+input string ADDRESS = "tcp://*:28282";
+input int REQUEST_POLLING_INTERVAL = 10;
+input int RESPONSE_TIMEOUT = 60000 * 5;  // 5 minutes for large data requests
+input int MIN_POINT_DISTANCE = 3;
+input bool VERBOSE = false;
+
+// Heartbeat global variable name - updated after each successful response
+const string HEARTBEAT_GV_NAME = "ZeroMQ_Server_LastResponse";
+
+// response message keys
+const string KEY_RESPONSE = "response";
+const string KEY_ERROR_CODE = "error_code";
+const string KEY_ERROR_CODE_DESCRIPTION = "error_code_description";
+const string KEY_ERROR_MESSAGE = "error_message";
+const string KEY_WARNING = "warning";
+
+// types of requests
+enum RequestAction {
+    GET_ACCOUNT_INFO,
+    GET_ACCOUNT_INFO_INTEGER,
+    GET_ACCOUNT_INFO_DOUBLE,
+    GET_SYMBOL_INFO,
+    GET_SYMBOL_MARKET_INFO,
+    GET_SYMBOL_INFO_INTEGER,
+    GET_SYMBOL_INFO_DOUBLE,
+    GET_SYMBOL_INFO_STRING,
+    GET_SYMBOL_TICK,
+    GET_ORDER,
+    GET_ORDERS,
+    GET_HISTORICAL_ORDERS,
+    GET_SYMBOLS,
+    GET_OHLCV,
+    GET_SIGNALS,
+    GET_SIGNAL_INFO,
+    DO_ORDER_SEND,
+    DO_ORDER_CLOSE,
+    DO_ORDER_DELETE,
+    DO_ORDER_MODIFY,
+    RUN_INDICATOR
+};
+
+// types of indicators (prefixed with IND_ to avoid conflicts with MQL5 built-in functions)
+enum Indicator {
+    IND_iAC, IND_iAD, IND_iADX, IND_iAlligator, IND_iAO, IND_iATR, IND_iBearsPower,
+    IND_iBands, IND_iBandsOnArray, IND_iBullsPower, IND_iCCI, IND_iCCIOnArray,
+    IND_iCustom, IND_iDeMarker, IND_iEnvelopes, IND_iEnvelopesOnArray, IND_iForce,
+    IND_iFractals, IND_iGator, IND_iIchimoku, IND_iBWMFI, IND_iMomentum,
+    IND_iMomentumOnArray, IND_iMFI, IND_iMA, IND_iMAOnArray, IND_iOsMA, IND_iMACD,
+    IND_iOBV, IND_iSAR, IND_iRSI, IND_iRSIOnArray, IND_iRVI, IND_iStdDev,
+    IND_iStdDevOnArray, IND_iStochastic, IND_iWPR
+};
+
+// ZeroMQ sockets
+Context* context = NULL;
+Socket* socket = NULL;
+
+// Trade object for trading operations
+CTrade trade;
+
+// Error recovery
+int consecutiveErrors = 0;
+int maxConsecutiveErrors = 10;
+
+//+------------------------------------------------------------------+
+//| Expert initialization function                                     |
+//+------------------------------------------------------------------+
+int OnInit() {
+    // Initialize heartbeat on startup
+    UpdateLastResponseTime();
+    Print("ZeroMQ Server EA v3.0 - Watchdog heartbeat enabled");
+
+    // Initialize ZeroMQ
+    Print("Initializing ZeroMQ context and socket...");
+    context = new Context(SCRIPT_NAME);
+    context.setBlocky(false);
+    socket = new Socket(context, ZMQ_REP);
+    socket.setSendHighWaterMark(1);
+    socket.setReceiveHighWaterMark(1);
+    socket.setSendTimeout(RESPONSE_TIMEOUT);
+
+    if (!socket.bind(ADDRESS)) {
+        Alert(StringFormat("Failed to bind socket on %s: %s", ADDRESS, Zmq::errorMessage(Zmq::errorNumber())));
+        return INIT_FAILED;
+    }
+
+    Print(StringFormat("Listening for requests on %s", ADDRESS));
+
+    // Set timer for polling (milliseconds to seconds conversion)
+    EventSetMillisecondTimer(REQUEST_POLLING_INTERVAL);
+
+    return INIT_SUCCEEDED;
+}
+
+//+------------------------------------------------------------------+
+//| Expert deinitialization function                                   |
+//+------------------------------------------------------------------+
+void OnDeinit(const int reason) {
+    EventKillTimer();
+    Cleanup();
+    Print("ZeroMQ Server EA stopped. Reason: ", reason);
+}
+
+//+------------------------------------------------------------------+
+//| Timer function - polls for ZeroMQ messages                         |
+//+------------------------------------------------------------------+
+void OnTimer() {
+    if (!_runMainLoop()) {
+        consecutiveErrors++;
+        Print(StringFormat("Socket error (%d/%d). Attempting recovery...",
+              consecutiveErrors, maxConsecutiveErrors));
+
+        if (consecutiveErrors >= maxConsecutiveErrors) {
+            Print("Too many consecutive errors. Restarting socket...");
+            if (_restartSocket()) {
+                Print("Socket restarted successfully.");
+                consecutiveErrors = 0;
+            }
+        }
+    } else {
+        consecutiveErrors = 0;
+    }
+}
+
+//+------------------------------------------------------------------+
+//| Tick function (not used but can process during ticks too)          |
+//+------------------------------------------------------------------+
+void OnTick() {
+    // Optional: process messages on tick as well for faster response
+    // _runMainLoop();
+}
+
+// Update last response timestamp - called after each successful response sent
+void UpdateLastResponseTime() {
+    GlobalVariableSet(HEARTBEAT_GV_NAME, (double)TimeCurrent());
+}
+
+// Cleanup function for EA termination
+void Cleanup() {
+    // Clear heartbeat on exit
+    GlobalVariableDel(HEARTBEAT_GV_NAME);
+
+    if (context != NULL) {
+        Print("Cleaning up ZeroMQ resources...");
+
+        if (socket != NULL) {
+            socket.unbind(ADDRESS);
+            delete socket;
+            socket = NULL;
+        }
+
+        context.destroy(0);
+        delete context;
+        context = NULL;
+    }
+}
+
+// Returns true if main loop cycle was successful, false if error occurred
+bool _runMainLoop() {
+    if (socket == NULL || context == NULL) return false;
+
+    PollItem poller[1];
+    socket.fillPollItem(poller[0], ZMQ_POLLIN);
+    ZmqMsg inMessage;
+
+    int pollResult = Socket::poll(poller, 1);  // Short poll, timer handles interval
+    if (pollResult == -1) {
+        int errNo = Zmq::errorNumber();
+        if (errNo != 11 && errNo != 4) {
+            Print("Poll error: " + Zmq::errorMessage(errNo) + " (errno: " + IntegerToString(errNo) + ")");
+            return false;
+        }
+        return true;
+    }
+
+    if (poller[0].hasInput()) {
+        if (_socketReceive(inMessage, true)) {
+            if (inMessage.size() > 0) {
+                string dataStr = inMessage.getData();
+                Trace("Received request: " + dataStr);
+                _processRequest(dataStr);
+            }
+            else {
+                sendError("Request was empty.");
+            }
+        } else {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// Restart the ZeroMQ socket
+bool _restartSocket() {
+    if (socket != NULL) {
+        socket.unbind(ADDRESS);
+        delete socket;
+        socket = NULL;
+    }
+
+    Sleep(500);
+
+    socket = new Socket(context, ZMQ_REP);
+    socket.setSendHighWaterMark(1);
+    socket.setReceiveHighWaterMark(1);
+    socket.setSendTimeout(RESPONSE_TIMEOUT);
+
+    if (!socket.bind(ADDRESS)) {
+        Print(StringFormat("Failed to rebind socket on %s: %s", ADDRESS, Zmq::errorMessage(Zmq::errorNumber())));
+        return false;
+    }
+
+    Print(StringFormat("Socket rebound successfully on %s", ADDRESS));
+    return true;
+}
+
+bool _socketReceive(ZmqMsg& msg, bool nowait=false) {
+    if (!socket.recv(msg, nowait)) {
+        Print("Failed to receive request.");
+        return false;
+    }
+    return true;
+}
+
+bool _socketSend(string response=NULL, bool nowait=false) {
+    if ((response == NULL && !socket.send(nowait)) || (response != NULL && !socket.send(response, nowait))) {
+        Alert("Critical error!  Failed to send response to client: " + Zmq::errorMessage(Zmq::errorNumber()));
+        return false;
+    }
+    UpdateLastResponseTime();
+    return true;
+}
+
+void _processRequest(string dataStr) {
+    CJAVal req;
+    if (!req.Deserialize(dataStr)) {
+        sendError("Failed to parse request.");
+        return;
+    }
+    string actionStr = req["action"].ToStr();
+    if (actionStr == "") {
+        sendError("No request action specified.");
+        return;
+    }
+
+    RequestAction action = (RequestAction)-1;
+    switch(StringToEnum(actionStr, action)) {
+        case GET_ACCOUNT_INFO: Get_AccountInfo(); break;
+        case GET_ACCOUNT_INFO_INTEGER: Get_AccountInfoInteger(req); break;
+        case GET_ACCOUNT_INFO_DOUBLE: Get_AccountInfoDouble(req); break;
+        case GET_SYMBOL_INFO: Get_SymbolInfo(req); break;
+        case GET_SYMBOL_MARKET_INFO: Get_SymbolMarketInfo(req); break;
+        case GET_SYMBOL_INFO_INTEGER: Get_SymbolInfoInteger(req); break;
+        case GET_SYMBOL_INFO_DOUBLE: Get_SymbolInfoDouble(req); break;
+        case GET_SYMBOL_INFO_STRING: Get_SymbolInfoString(req); break;
+        case GET_SYMBOL_TICK: Get_SymbolTick(req); break;
+        case GET_ORDER: Get_Order(req); break;
+        case GET_ORDERS: Get_Orders(); break;
+        case GET_HISTORICAL_ORDERS: Get_HistoricalOrders(); break;
+        case GET_SYMBOLS: Get_Symbols(); break;
+        case GET_OHLCV: Get_OHLCV(req); break;
+        case GET_SIGNALS: Get_Signals(); break;
+        case GET_SIGNAL_INFO: Get_SignalInfo(req); break;
+        case DO_ORDER_SEND: Do_OrderSend(req); break;
+        case DO_ORDER_MODIFY: Do_OrderModify(req); break;
+        case DO_ORDER_CLOSE: Do_OrderClose(req); break;
+        case DO_ORDER_DELETE: Do_OrderDelete(req); break;
+        case RUN_INDICATOR: Run_Indicator(req); break;
+        default:
+            sendError(StringFormat("Unrecognized requested action (%s).", actionStr));
+            break;
+    }
+}
+
+void _serializeAndSendResponse(CJAVal& resp) {
+    string strResp = resp.Serialize();
+    if (_socketSend(strResp)) {
+        Trace("Sent response: " + strResp);
+    }
+}
+
+void sendResponse(CJAVal& data, string warning=NULL) {
+    CJAVal resp;
+    resp[KEY_RESPONSE].Set(data);
+    if (warning != NULL) resp[KEY_WARNING] = warning;
+    _serializeAndSendResponse(resp);
+}
+
+void sendResponse(string val, string warning=NULL) {
+    CJAVal resp;
+    resp[KEY_RESPONSE] = val;
+    if (warning != NULL) resp[KEY_WARNING] = warning;
+    _serializeAndSendResponse(resp);
+}
+
+void sendResponse(double val, string warning=NULL) {
+    CJAVal resp;
+    resp[KEY_RESPONSE] = val;
+    if (warning != NULL) resp[KEY_WARNING] = warning;
+    _serializeAndSendResponse(resp);
+}
+
+void sendResponse(long val, string warning=NULL) {
+    CJAVal resp;
+    resp[KEY_RESPONSE] = val;
+    if (warning != NULL) resp[KEY_WARNING] = warning;
+    _serializeAndSendResponse(resp);
+}
+
+void sendError(int code, string msg) {
+    CJAVal resp;
+    resp[KEY_ERROR_CODE] = code;
+    resp[KEY_ERROR_CODE_DESCRIPTION] = CustomErrorDescription(code);
+    resp[KEY_ERROR_MESSAGE] = msg;
+    _serializeAndSendResponse(resp);
+}
+
+void sendError(int code) {
+    CJAVal resp;
+    resp[KEY_ERROR_CODE] = code;
+    resp[KEY_ERROR_CODE_DESCRIPTION] = CustomErrorDescription(code);
+    _serializeAndSendResponse(resp);
+}
+
+void sendError(string msg) {
+    CJAVal resp;
+    resp[KEY_ERROR_MESSAGE] = msg;
+    _serializeAndSendResponse(resp);
+}
+
+void sendErrorMissingParam(string paramName) {
+    sendError(StringFormat("Missing \"%s\" param.", paramName));
+}
+
+bool assertParamExists(CJAVal& req, string paramName) {
+    if (IsNullOrMissing(req, paramName)) {
+        sendErrorMissingParam(paramName);
+        return false;
+    }
+    return true;
+}
+
+bool assertParamArrayExistsAndNotEmpty(CJAVal& req, string paramName) {
+    if (!assertParamExists(req, paramName)) return false;
+    CJAVal* param = req[paramName];
+    if (param.m_type != jtARRAY) {
+        sendError(StringFormat("Param \"%s\" is not an array.", paramName));
+        return false;
+    }
+    if (param.Size() == 0) {
+        sendError(StringFormat("Param \"%s[]\" is empty.", paramName));
+        return false;
+    }
+    return true;
+}
+
+void sendOrder(ulong ticket, string warning=NULL) {
+    if (PositionSelectByTicket(ticket)) {
+        CJAVal order;
+        _getSelectedPosition(order);
+        sendResponse(order, warning);
+        return;
+    }
+    else if (OrderSelect(ticket)) {
+        CJAVal order;
+        _getSelectedOrder(order);
+        sendResponse(order, warning);
+        return;
+    }
+    else if (HistoryOrderSelect(ticket)) {
+        CJAVal order;
+        _getSelectedHistoryOrder(order);
+        sendResponse(order, warning);
+        return;
+    }
+    else {
+        sendError(StringFormat("Order/Position # %d is not found.", ticket));
+    }
+}
+
+void Get_AccountInfo() {
+    CJAVal account_info;
+    account_info["login"] = AccountInfoInteger(ACCOUNT_LOGIN);
+    account_info["trade_mode"] = AccountInfoInteger(ACCOUNT_TRADE_MODE);
+    account_info["name"] = AccountInfoString(ACCOUNT_NAME);
+    account_info["server"] = AccountInfoString(ACCOUNT_SERVER);
+    account_info["currency"] = AccountInfoString(ACCOUNT_CURRENCY);
+    account_info["company"] = AccountInfoString(ACCOUNT_COMPANY);
+    sendResponse(account_info);
+}
+
+void Get_AccountInfoInteger(CJAVal& req) {
+    if (!IsNullOrMissing(req, "property_name")) {
+        string propertyName = req["property_name"].ToStr();
+        ENUM_ACCOUNT_INFO_INTEGER action = StringToEnum(propertyName, (ENUM_ACCOUNT_INFO_INTEGER)-1);
+        if (action == -1) {
+            sendError(StringFormat("Unrecognized account integer property: %s", propertyName));
+        } else {
+            sendResponse(AccountInfoInteger(action));
+        }
+    }
+    else if (!IsNullOrMissing(req, "property_id")) {
+        sendResponse(AccountInfoInteger((ENUM_ACCOUNT_INFO_INTEGER)req["property_id"].ToInt()));
+    }
+    else {
+        sendError("Must include either \"property_name\" or \"property_id\" param.");
+    }
+}
+
+void Get_AccountInfoDouble(CJAVal& req) {
+    if (!IsNullOrMissing(req, "property_name")) {
+        string propertyName = req["property_name"].ToStr();
+        ENUM_ACCOUNT_INFO_DOUBLE action = StringToEnum(propertyName, (ENUM_ACCOUNT_INFO_DOUBLE)-1);
+        if (action == -1) {
+            sendError(StringFormat("Unrecognized account double property: %s", propertyName));
+        } else {
+            sendResponse(AccountInfoDouble(action));
+        }
+    }
+    else if (!IsNullOrMissing(req, "property_id")) {
+        sendResponse(AccountInfoDouble((ENUM_ACCOUNT_INFO_DOUBLE)req["property_id"].ToInt()));
+    }
+    else {
+        sendError("Must include either \"property_name\" or \"property_id\" param.");
+    }
+}
+
+void Get_SymbolInfo(CJAVal& req) {
+    if (!assertParamArrayExistsAndNotEmpty(req, "names")) return;
+    CJAVal* names = req["names"];
+    CJAVal symbols;
+    for (int i = 0; i < names.Size(); i++) {
+        string name = names[i].ToStr();
+        if (!SymbolSelect(name, true)) {
+            sendError(GetLastError(), name);
+            return;
+        }
+        CJAVal symbol;
+        symbol["name"] = name;
+        symbol["point"] = SymbolInfoDouble(name, SYMBOL_POINT);
+        symbol["digits"] = SymbolInfoInteger(name, SYMBOL_DIGITS);
+        symbol["volume_min"] = SymbolInfoDouble(name, SYMBOL_VOLUME_MIN);
+        symbol["volume_step"] = SymbolInfoDouble(name, SYMBOL_VOLUME_STEP);
+        symbol["volume_max"] = SymbolInfoDouble(name, SYMBOL_VOLUME_MAX);
+        symbol["trade_contract_size"] = SymbolInfoDouble(name, SYMBOL_TRADE_CONTRACT_SIZE);
+        symbol["trade_tick_value"] = SymbolInfoDouble(name, SYMBOL_TRADE_TICK_VALUE);
+        symbol["trade_tick_size"] = SymbolInfoDouble(name, SYMBOL_TRADE_TICK_SIZE);
+        symbol["trade_stops_level"] = SymbolInfoInteger(name, SYMBOL_TRADE_STOPS_LEVEL);
+        symbol["trade_freeze_level"] = SymbolInfoInteger(name, SYMBOL_TRADE_FREEZE_LEVEL);
+        symbols[name].Set(symbol);
+    }
+    sendResponse(symbols);
+}
+
+void Get_SymbolMarketInfo(CJAVal& req) {
+    if (!assertParamExists(req, "symbol") || !assertParamExists(req, "property")) return;
+    string symbol = req["symbol"].ToStr();
+    string strProperty = req["property"].ToStr();
+    if (!SymbolSelect(symbol, true)) {
+        sendError(GetLastError(), symbol);
+        return;
+    }
+
+    ENUM_SYMBOL_INFO_INTEGER intProp = StringToEnum(strProperty, (ENUM_SYMBOL_INFO_INTEGER)-1);
+    if (intProp != -1) { sendResponse(SymbolInfoInteger(symbol, intProp)); return; }
+
+    ENUM_SYMBOL_INFO_DOUBLE dblProp = StringToEnum(strProperty, (ENUM_SYMBOL_INFO_DOUBLE)-1);
+    if (dblProp != -1) { sendResponse(SymbolInfoDouble(symbol, dblProp)); return; }
+
+    ENUM_SYMBOL_INFO_STRING strProp = StringToEnum(strProperty, (ENUM_SYMBOL_INFO_STRING)-1);
+    if (strProp != -1) { sendResponse(SymbolInfoString(symbol, strProp)); return; }
+
+    sendError(StringFormat("Unrecognized market info property: %s", strProperty));
+}
+
+void Get_SymbolInfoInteger(CJAVal& req) {
+    if (!assertParamExists(req, "symbol")) return;
+    string symbol = req["symbol"].ToStr();
+    if (!IsNullOrMissing(req, "property_name")) {
+        ENUM_SYMBOL_INFO_INTEGER action = StringToEnum(req["property_name"].ToStr(), (ENUM_SYMBOL_INFO_INTEGER)-1);
+        if (action == -1) sendError(StringFormat("Unrecognized symbol integer property: %s", req["property_name"].ToStr()));
+        else sendResponse(SymbolInfoInteger(symbol, action));
+    }
+    else if (!IsNullOrMissing(req, "property_id")) {
+        sendResponse(SymbolInfoInteger(symbol, (ENUM_SYMBOL_INFO_INTEGER)req["property_id"].ToInt()));
+    }
+    else sendError("Must include either \"property_name\" or \"property_id\" param.");
+}
+
+void Get_SymbolInfoDouble(CJAVal& req) {
+    if (!assertParamExists(req, "symbol")) return;
+    string symbol = req["symbol"].ToStr();
+    if (!IsNullOrMissing(req, "property_name")) {
+        ENUM_SYMBOL_INFO_DOUBLE action = StringToEnum(req["property_name"].ToStr(), (ENUM_SYMBOL_INFO_DOUBLE)-1);
+        if (action == -1) sendError(StringFormat("Unrecognized symbol double property: %s", req["property_name"].ToStr()));
+        else sendResponse(SymbolInfoDouble(symbol, action));
+    }
+    else if (!IsNullOrMissing(req, "property_id")) {
+        sendResponse(SymbolInfoDouble(symbol, (ENUM_SYMBOL_INFO_DOUBLE)req["property_id"].ToInt()));
+    }
+    else sendError("Must include either \"property_name\" or \"property_id\" param.");
+}
+
+void Get_SymbolInfoString(CJAVal& req) {
+    if (!assertParamExists(req, "symbol")) return;
+    string symbol = req["symbol"].ToStr();
+    if (!IsNullOrMissing(req, "property_name")) {
+        ENUM_SYMBOL_INFO_STRING action = StringToEnum(req["property_name"].ToStr(), (ENUM_SYMBOL_INFO_STRING)-1);
+        if (action == -1) sendError(StringFormat("Unrecognized symbol string property: %s", req["property_name"].ToStr()));
+        else sendResponse(SymbolInfoString(symbol, action));
+    }
+    else if (!IsNullOrMissing(req, "property_id")) {
+        sendResponse(SymbolInfoString(symbol, (ENUM_SYMBOL_INFO_STRING)req["property_id"].ToInt()));
+    }
+    else sendError("Must include either \"property_name\" or \"property_id\" param.");
+}
+
+void Get_SymbolTick(CJAVal& req) {
+    if (!assertParamExists(req, "symbol")) return;
+    string symbol = req["symbol"].ToStr();
+    if (!SymbolSelect(symbol, true)) {
+        sendError(GetLastError(), symbol);
+        return;
+    }
+    MqlTick lastTick;
+    if(SymbolInfoTick(symbol, lastTick)) {
+        CJAVal tick;
+        tick["time"] = (long)lastTick.time;
+        tick["bid"] = lastTick.bid;
+        tick["ask"] = lastTick.ask;
+        tick["last"] = lastTick.last;
+        tick["volume"] = (long)lastTick.volume;
+        sendResponse(tick);
+    } else {
+        sendError(GetLastError());
+    }
+}
+
+void Get_Order(CJAVal& req) {
+    if (!assertParamExists(req, "ticket")) return;
+    sendOrder((ulong)req["ticket"].ToInt());
+}
+
+void Get_Orders() {
+    CJAVal orders;
+    int total = PositionsTotal();
+    for(int i = 0; i < total; i++) {
+        ulong ticket = PositionGetTicket(i);
+        if(ticket > 0 && PositionSelectByTicket(ticket)) {
+            CJAVal curOrder;
+            _getSelectedPosition(curOrder);
+            orders.Add(curOrder);
+        }
+    }
+    total = OrdersTotal();
+    for(int i = 0; i < total; i++) {
+        ulong ticket = OrderGetTicket(i);
+        if(ticket > 0 && OrderSelect(ticket)) {
+            CJAVal curOrder;
+            _getSelectedOrder(curOrder);
+            orders.Add(curOrder);
+        }
+    }
+    sendResponse(orders);
+}
+
+void Get_HistoricalOrders() {
+    datetime from = TimeCurrent() - 90*24*60*60;
+    datetime to = TimeCurrent();
+    if(!HistorySelect(from, to)) {
+        sendError(GetLastError(), "Failed to select history");
+        return;
+    }
+    CJAVal deals;
+    int total = HistoryDealsTotal();
+    for(int i = 0; i < total; i++) {
+        ulong ticket = HistoryDealGetTicket(i);
+        if(ticket > 0 && HistoryDealGetInteger(ticket, DEAL_ENTRY) == DEAL_ENTRY_OUT) {
+            CJAVal curDeal;
+            _getSelectedHistoryDeal(ticket, curDeal);
+            deals.Add(curDeal);
+        }
+    }
+    sendResponse(deals);
+}
+
+void _getSelectedPosition(CJAVal& order) {
+    order["ticket"] = PositionGetInteger(POSITION_TICKET);
+    order["magic_number"] = PositionGetInteger(POSITION_MAGIC);
+    order["symbol"] = PositionGetString(POSITION_SYMBOL);
+    order["order_type"] = PositionGetInteger(POSITION_TYPE);
+    order["lots"] = PositionGetDouble(POSITION_VOLUME);
+    order["open_price"] = PositionGetDouble(POSITION_PRICE_OPEN);
+    order["close_price"] = PositionGetDouble(POSITION_PRICE_CURRENT);
+    order["open_time"] = TimeToString((datetime)PositionGetInteger(POSITION_TIME), TIME_DATE|TIME_SECONDS);
+    order["close_time"] = "";
+    order["expiration"] = "";
+    order["sl"] = PositionGetDouble(POSITION_SL);
+    order["tp"] = PositionGetDouble(POSITION_TP);
+    order["profit"] = PositionGetDouble(POSITION_PROFIT);
+    order["commission"] = 0.0;
+    order["swap"] = PositionGetDouble(POSITION_SWAP);
+    order["comment"] = PositionGetString(POSITION_COMMENT);
+}
+
+void _getSelectedOrder(CJAVal& order) {
+    order["ticket"] = OrderGetInteger(ORDER_TICKET);
+    order["magic_number"] = OrderGetInteger(ORDER_MAGIC);
+    order["symbol"] = OrderGetString(ORDER_SYMBOL);
+    order["order_type"] = OrderGetInteger(ORDER_TYPE);
+    order["lots"] = OrderGetDouble(ORDER_VOLUME_CURRENT);
+    order["open_price"] = OrderGetDouble(ORDER_PRICE_OPEN);
+    order["close_price"] = 0.0;
+    order["open_time"] = TimeToString((datetime)OrderGetInteger(ORDER_TIME_SETUP), TIME_DATE|TIME_SECONDS);
+    order["close_time"] = "";
+    order["expiration"] = TimeToString((datetime)OrderGetInteger(ORDER_TIME_EXPIRATION), TIME_DATE|TIME_SECONDS);
+    order["sl"] = OrderGetDouble(ORDER_SL);
+    order["tp"] = OrderGetDouble(ORDER_TP);
+    order["profit"] = 0.0;
+    order["commission"] = 0.0;
+    order["swap"] = 0.0;
+    order["comment"] = OrderGetString(ORDER_COMMENT);
+}
+
+void _getSelectedHistoryDeal(ulong ticket, CJAVal& deal) {
+    deal["ticket"] = HistoryDealGetInteger(ticket, DEAL_TICKET);
+    deal["magic_number"] = HistoryDealGetInteger(ticket, DEAL_MAGIC);
+    deal["symbol"] = HistoryDealGetString(ticket, DEAL_SYMBOL);
+    deal["order_type"] = HistoryDealGetInteger(ticket, DEAL_TYPE);
+    deal["lots"] = HistoryDealGetDouble(ticket, DEAL_VOLUME);
+    deal["open_price"] = HistoryDealGetDouble(ticket, DEAL_PRICE);
+    deal["close_price"] = HistoryDealGetDouble(ticket, DEAL_PRICE);
+    deal["open_time"] = TimeToString((datetime)HistoryDealGetInteger(ticket, DEAL_TIME), TIME_DATE|TIME_SECONDS);
+    deal["close_time"] = TimeToString((datetime)HistoryDealGetInteger(ticket, DEAL_TIME), TIME_DATE|TIME_SECONDS);
+    deal["expiration"] = "";
+    deal["sl"] = 0.0;
+    deal["tp"] = 0.0;
+    deal["profit"] = HistoryDealGetDouble(ticket, DEAL_PROFIT);
+    deal["commission"] = HistoryDealGetDouble(ticket, DEAL_COMMISSION);
+    deal["swap"] = HistoryDealGetDouble(ticket, DEAL_SWAP);
+    deal["comment"] = HistoryDealGetString(ticket, DEAL_COMMENT);
+}
+
+void _getSelectedHistoryOrder(CJAVal& order) {
+    order["ticket"] = HistoryOrderGetInteger((ulong)0, ORDER_TICKET);
+    order["magic_number"] = HistoryOrderGetInteger((ulong)0, ORDER_MAGIC);
+    order["symbol"] = HistoryOrderGetString((ulong)0, ORDER_SYMBOL);
+    order["order_type"] = HistoryOrderGetInteger((ulong)0, ORDER_TYPE);
+    order["lots"] = HistoryOrderGetDouble((ulong)0, ORDER_VOLUME_INITIAL);
+    order["open_price"] = HistoryOrderGetDouble((ulong)0, ORDER_PRICE_OPEN);
+    order["close_price"] = HistoryOrderGetDouble((ulong)0, ORDER_PRICE_CURRENT);
+    order["open_time"] = TimeToString((datetime)HistoryOrderGetInteger((ulong)0, ORDER_TIME_SETUP), TIME_DATE|TIME_SECONDS);
+    order["close_time"] = TimeToString((datetime)HistoryOrderGetInteger((ulong)0, ORDER_TIME_DONE), TIME_DATE|TIME_SECONDS);
+    order["expiration"] = TimeToString((datetime)HistoryOrderGetInteger((ulong)0, ORDER_TIME_EXPIRATION), TIME_DATE|TIME_SECONDS);
+    order["sl"] = HistoryOrderGetDouble((ulong)0, ORDER_SL);
+    order["tp"] = HistoryOrderGetDouble((ulong)0, ORDER_TP);
+    order["profit"] = 0.0;
+    order["commission"] = 0.0;
+    order["swap"] = 0.0;
+    order["comment"] = HistoryOrderGetString((ulong)0, ORDER_COMMENT);
+}
+
+void Get_Symbols() {
+    CJAVal symbols;
+    int count = SymbolsTotal(false);
+    for (int i = 0; i < count; i++) {
+        symbols.Add(SymbolName(i, false));
+    }
+    sendResponse(symbols);
+}
+
+void Get_OHLCV(CJAVal& req) {
+    if (!assertParamExists(req, "symbol") || !assertParamExists(req, "timeframe")
+            || !assertParamExists(req, "limit") || !assertParamExists(req, "timeout")) return;
+
+    string symbol = req["symbol"].ToStr();
+    ENUM_TIMEFRAMES timeframe = (ENUM_TIMEFRAMES)req["timeframe"].ToInt();
+    int limit = (int)req["limit"].ToInt();
+    long timeout = req["timeout"].ToInt();
+    int offset = GetDefault(req, "offset", 0);
+
+    if (limit <= 0 || offset < 0 || timeout <= 0) {
+        sendError("Invalid parameters");
+        return;
+    }
+
+    if (!SymbolSelect(symbol, true)) {
+        sendError("Symbol selection failed: " + symbol);
+        return;
+    }
+
+    MqlRates rates[];
+    ArraySetAsSeries(rates, false);
+    int delay = 100;
+    long maxTries = timeout / delay;
+    int numResults = -1;
+
+    for (int attempt = 0; attempt < maxTries && numResults == -1; attempt++) {
+        numResults = CopyRates(symbol, timeframe, offset, limit, rates);
+        if (numResults == -1) {
+            int err = GetLastError();
+            if (err == ERR_HISTORY_WILL_UPDATED || err == 4066) Sleep(delay);
+            else { sendError("CopyRates failed: " + IntegerToString(err)); return; }
+        }
+    }
+
+    if (numResults <= 0) {
+        sendError("No data available");
+        return;
+    }
+
+    CJAVal ohlcv;
+    for (int i = 0; i < numResults; i++) {
+        CJAVal curBar;
+        curBar["time"] = (long)rates[i].time;
+        curBar["open"] = rates[i].open;
+        curBar["high"] = rates[i].high;
+        curBar["low"] = rates[i].low;
+        curBar["close"] = rates[i].close;
+        curBar["tick_volume"] = (long)rates[i].tick_volume;
+        curBar["real_volume"] = (long)rates[i].real_volume;
+        curBar["spread"] = rates[i].spread;
+        ohlcv.Add(curBar);
+    }
+    sendResponse(ohlcv);
+}
+
+void Get_Signals() {
+    CJAVal signals;
+    int total = SignalBaseTotal();
+    for (int i = 0; i < total; i++) {
+        if (SignalBaseSelect(i)) signals.Add(SignalBaseGetString(SIGNAL_BASE_NAME));
+    }
+    sendResponse(signals);
+}
+
+void Get_SignalInfo(CJAVal& req) {
+    if (!assertParamArrayExistsAndNotEmpty(req, "names")) return;
+    CJAVal* reqNames = req["names"];
+    CJAVal signals;
+    int total = SignalBaseTotal();
+    for (int i = 0; i < total; i++) {
+        if (SignalBaseSelect(i)) {
+            string name = SignalBaseGetString(SIGNAL_BASE_NAME);
+            if (ArrayEraseElement(reqNames.m_e, name)) {
+                CJAVal signal;
+                signal["author_login"] = SignalBaseGetString(SIGNAL_BASE_AUTHOR_LOGIN);
+                signal["broker"] = SignalBaseGetString(SIGNAL_BASE_BROKER);
+                signal["broker_server"] = SignalBaseGetString(SIGNAL_BASE_BROKER_SERVER);
+                signal["name"] = name;
+                signal["currency"] = SignalBaseGetString(SIGNAL_BASE_CURRENCY);
+                signal["date_published"] = SignalBaseGetInteger(SIGNAL_BASE_DATE_PUBLISHED);
+                signal["date_started"] = SignalBaseGetInteger(SIGNAL_BASE_DATE_STARTED);
+                signal["id"] = SignalBaseGetInteger(SIGNAL_BASE_ID);
+                signal["leverage"] = SignalBaseGetInteger(SIGNAL_BASE_LEVERAGE);
+                signal["pips"] = SignalBaseGetInteger(SIGNAL_BASE_PIPS);
+                signal["rating"] = SignalBaseGetInteger(SIGNAL_BASE_RATING);
+                signal["subscribers"] = SignalBaseGetInteger(SIGNAL_BASE_SUBSCRIBERS);
+                signal["trades"] = SignalBaseGetInteger(SIGNAL_BASE_TRADES);
+                signal["trade_mode"] = SignalBaseGetInteger(SIGNAL_BASE_TRADE_MODE);
+                signal["balance"] = SignalBaseGetDouble(SIGNAL_BASE_BALANCE);
+                signal["equity"] = SignalBaseGetDouble(SIGNAL_BASE_EQUITY);
+                signal["gain"] = SignalBaseGetDouble(SIGNAL_BASE_GAIN);
+                signal["max_drawdown"] = SignalBaseGetDouble(SIGNAL_BASE_MAX_DRAWDOWN);
+                signal["price"] = SignalBaseGetDouble(SIGNAL_BASE_PRICE);
+                signal["roi"] = SignalBaseGetDouble(SIGNAL_BASE_ROI);
+                signals[name].Set(signal);
+            }
+        }
+    }
+    if (reqNames.Size() == 0) sendResponse(signals);
+    else sendError(StringFormat("Signals not found: %s", reqNames.Serialize()));
+}
+
+void Do_OrderSend(CJAVal& req) {
+    if (!assertParamExists(req, "symbol") || !assertParamExists(req, "order_type")
+            || !assertParamExists(req, "lots") || !assertParamExists(req, "comment")) return;
+
+    if (!IsNullOrMissing(req, "sl") && !IsNullOrMissing(req, "sl_points")) {
+        sendError("Stop-loss cannot be both relative and absolute.");
+        return;
+    }
+    if (!IsNullOrMissing(req, "tp") && !IsNullOrMissing(req, "tp_points")) {
+        sendError("Take-profit cannot be both relative and absolute.");
+        return;
+    }
+
+    string symbol = req["symbol"].ToStr();
+    int orderType = (int)req["order_type"].ToInt();
+    double lots = req["lots"].ToDbl();
+    string comment = req["comment"].ToStr();
+
+    if (!SymbolSelect(symbol, true)) { sendError(GetLastError(), symbol); return; }
+    if (!IsValidTradeOperation(orderType)) { sendError("Invalid trade operation"); return; }
+
+    ENUM_ORDER_TYPE mql5OrderType = ConvertOrderType(orderType);
+    bool isPending = (mql5OrderType >= ORDER_TYPE_BUY_LIMIT);
+
+    if (isPending && IsNullOrMissing(req, "price")) {
+        sendError("Pending order requires price parameter.");
+        return;
+    }
+
+    double price = GetDefault(req, "price", DefaultOpenPrice(symbol, mql5OrderType));
+    int slippage = GetDefault(req, "slippage", DefaultSlippage(symbol));
+    double stopLoss = GetDefault(req, "sl", 0.0);
+    double takeProfit = GetDefault(req, "tp", 0.0);
+    int slPoints = GetDefault(req, "sl_points", 0);
+    int tpPoints = GetDefault(req, "tp_points", 0);
+    int magicNumber = GetDefault(req, "magic_number", 0);
+
+    if (slPoints > 0) stopLoss = CalculateSL(symbol, mql5OrderType, price, slPoints);
+    if (tpPoints > 0) takeProfit = CalculateTP(symbol, mql5OrderType, price, tpPoints);
+
+    lots = NormalizeLots(symbol, lots);
+    price = NormalizePrice(symbol, price);
+    stopLoss = NormalizePrice(symbol, stopLoss);
+    takeProfit = NormalizePrice(symbol, takeProfit);
+
+    trade.SetDeviationInPoints(slippage);
+    trade.SetExpertMagicNumber(magicNumber);
+    trade.SetTypeFilling(ORDER_FILLING_FOK);
+
+    bool result = false;
+    if (mql5OrderType == ORDER_TYPE_BUY) result = trade.Buy(lots, symbol, 0, stopLoss, takeProfit, comment);
+    else if (mql5OrderType == ORDER_TYPE_SELL) result = trade.Sell(lots, symbol, 0, stopLoss, takeProfit, comment);
+    else result = trade.OrderOpen(symbol, mql5OrderType, lots, 0, price, stopLoss, takeProfit, ORDER_TIME_GTC, 0, comment);
+
+    if (!result) {
+        sendError(trade.ResultRetcode(), "Failed: " + trade.ResultRetcodeDescription());
+        return;
+    }
+
+    ulong ticket = trade.ResultOrder();
+    if (ticket == 0) ticket = trade.ResultDeal();
+    if (ticket > 0) sendOrder(ticket);
+    else sendError("Order created but ticket not found");
+}
+
+void Do_OrderModify(CJAVal& req) {
+    if (!assertParamExists(req, "ticket")) return;
+    ulong ticket = (ulong)req["ticket"].ToInt();
+
+    if (!IsNullOrMissing(req, "sl") && !IsNullOrMissing(req, "sl_points")) {
+        sendError("Stop-loss cannot be both relative and absolute.");
+        return;
+    }
+    if (!IsNullOrMissing(req, "tp") && !IsNullOrMissing(req, "tp_points")) {
+        sendError("Take-profit cannot be both relative and absolute.");
+        return;
+    }
+
+    bool isPosition = PositionSelectByTicket(ticket);
+    bool isOrder = !isPosition && OrderSelect(ticket);
+
+    if (!isPosition && !isOrder) {
+        sendError(StringFormat("Order/Position # %d not found.", ticket));
+        return;
+    }
+
+    string symbol = isPosition ? PositionGetString(POSITION_SYMBOL) : OrderGetString(ORDER_SYMBOL);
+    double stopLoss = 0, takeProfit = 0, newPrice = 0;
+
+    if (isPosition) {
+        stopLoss = GetDefault(req, "sl", PositionGetDouble(POSITION_SL));
+        takeProfit = GetDefault(req, "tp", PositionGetDouble(POSITION_TP));
+        int slPoints = GetDefault(req, "sl_points", 0);
+        int tpPoints = GetDefault(req, "tp_points", 0);
+        if (slPoints > 0) {
+            ENUM_POSITION_TYPE posType = (ENUM_POSITION_TYPE)PositionGetInteger(POSITION_TYPE);
+            stopLoss = CalculateSL(symbol, posType == POSITION_TYPE_BUY ? ORDER_TYPE_BUY : ORDER_TYPE_SELL,
+                                  PositionGetDouble(POSITION_PRICE_OPEN), slPoints);
+        }
+        if (tpPoints > 0) {
+            ENUM_POSITION_TYPE posType = (ENUM_POSITION_TYPE)PositionGetInteger(POSITION_TYPE);
+            takeProfit = CalculateTP(symbol, posType == POSITION_TYPE_BUY ? ORDER_TYPE_BUY : ORDER_TYPE_SELL,
+                                    PositionGetDouble(POSITION_PRICE_OPEN), tpPoints);
+        }
+        stopLoss = NormalizePrice(symbol, stopLoss);
+        takeProfit = NormalizePrice(symbol, takeProfit);
+        if (!trade.PositionModify(ticket, stopLoss, takeProfit)) {
+            sendError(trade.ResultRetcode(), "Failed to modify position");
+            return;
+        }
+    } else {
+        newPrice = GetDefault(req, "price", OrderGetDouble(ORDER_PRICE_OPEN));
+        stopLoss = GetDefault(req, "sl", OrderGetDouble(ORDER_SL));
+        takeProfit = GetDefault(req, "tp", OrderGetDouble(ORDER_TP));
+        int slPoints = GetDefault(req, "sl_points", 0);
+        int tpPoints = GetDefault(req, "tp_points", 0);
+        if (slPoints > 0) stopLoss = CalculateSL(symbol, (ENUM_ORDER_TYPE)OrderGetInteger(ORDER_TYPE), newPrice, slPoints);
+        if (tpPoints > 0) takeProfit = CalculateTP(symbol, (ENUM_ORDER_TYPE)OrderGetInteger(ORDER_TYPE), newPrice, tpPoints);
+        newPrice = NormalizePrice(symbol, newPrice);
+        stopLoss = NormalizePrice(symbol, stopLoss);
+        takeProfit = NormalizePrice(symbol, takeProfit);
+        if (!trade.OrderModify(ticket, newPrice, stopLoss, takeProfit, ORDER_TIME_GTC, 0)) {
+            sendError(trade.ResultRetcode(), "Failed to modify order");
+            return;
+        }
+    }
+    sendOrder(ticket);
+}
+
+void Do_OrderClose(CJAVal& req) {
+    if (!assertParamExists(req, "ticket")) return;
+    ulong ticket = (ulong)req["ticket"].ToInt();
+    if (!PositionSelectByTicket(ticket)) {
+        sendError(StringFormat("Position # %d not found.", ticket));
+        return;
+    }
+    double lots = GetDefault(req, "lots", PositionGetDouble(POSITION_VOLUME));
+    int slippage = GetDefault(req, "slippage", DefaultSlippage(PositionGetString(POSITION_SYMBOL)));
+    lots = NormalizeLots(PositionGetString(POSITION_SYMBOL), lots);
+    trade.SetDeviationInPoints(slippage);
+    if (!trade.PositionClose(ticket, slippage)) {
+        sendError(trade.ResultRetcode(), "Failed to close position");
+        return;
+    }
+    sendResponse(StringFormat("Closed position # %d", ticket));
+}
+
+void Do_OrderDelete(CJAVal& req) {
+    if (!assertParamExists(req, "ticket")) return;
+    ulong ticket = (ulong)req["ticket"].ToInt();
+    bool closeIfOpened = GetDefault(req, "close_if_opened", false);
+
+    if (PositionSelectByTicket(ticket)) {
+        if (closeIfOpened) { Do_OrderClose(req); return; }
+        else { sendError("Ticket is a position. Use close_if_opened=true."); return; }
+    }
+
+    if (!OrderSelect(ticket)) {
+        sendError(StringFormat("Order # %d not found.", ticket));
+        return;
+    }
+    if (!trade.OrderDelete(ticket)) {
+        sendError(trade.ResultRetcode(), "Failed to delete order");
+        return;
+    }
+    sendResponse(StringFormat("Deleted order # %d", ticket));
+}
+
+void Run_Indicator(CJAVal& req) {
+    if (!assertParamExists(req, "indicator") || !assertParamExists(req, "argv") || !assertParamExists(req, "timeout")) return;
+
+    string strIndicator = req["indicator"].ToStr();
+    CJAVal argv = req["argv"];
+    long timeout = req["timeout"].ToInt();
+
+    Indicator indicator = StringToEnum(strIndicator, (Indicator)-1);
+    if (indicator == -1) {
+        sendError("Indicator not recognized: " + strIndicator);
+        return;
+    }
+
+    double results[];
+    ArrayResize(results, 1);
+    int delay = 100;
+    long maxTries = timeout / delay;
+    bool isDone = false;
+
+    for (int tryNum = 0; tryNum < maxTries && !isDone; tryNum++) {
+        int retVal = _runIndicator(indicator, argv, results);
+        if (retVal == -1) { sendError("Indicator not recognized"); return; }
+        int err = GetLastError();
+        if (err == ERR_HISTORY_WILL_UPDATED || err == 4066) Sleep(delay);
+        else if (err != 0) { sendError(err); return; }
+        else isDone = true;
+    }
+
+    if (!isDone) { sendError("Timeout waiting for indicator data"); return; }
+
+    if (ArraySize(results) == 1) sendResponse(results[0]);
+    else {
+        CJAVal arr;
+        for (int i = 0; i < ArraySize(results); i++) arr.Add(results[i]);
+        sendResponse(arr);
+    }
+}
+
+int _runIndicator(Indicator indicator, CJAVal& argv, double& results[]) {
+    string symbol = argv[0].ToStr();
+    ENUM_TIMEFRAMES period = (ENUM_TIMEFRAMES)argv[1].ToInt();
+    int shift = (int)argv[2].ToInt();
+    int handle = -1;
+    double buffer[];
+    ArraySetAsSeries(buffer, true);
+
+    switch(indicator) {
+        case IND_iAC:
+            handle = iAC(symbol, period);
+            break;
+        case IND_iAD:
+            handle = iAD(symbol, period, VOLUME_TICK);
+            break;
+        case IND_iATR:
+            handle = iATR(symbol, period, (int)argv[2].ToInt());
+            break;
+        case IND_iRSI:
+            handle = iRSI(symbol, period, (int)argv[2].ToInt(), (ENUM_APPLIED_PRICE)argv[3].ToInt());
+            break;
+        case IND_iMA:
+            handle = iMA(symbol, period, (int)argv[2].ToInt(), (int)argv[3].ToInt(),
+                        (ENUM_MA_METHOD)argv[4].ToInt(), (ENUM_APPLIED_PRICE)argv[5].ToInt());
+            break;
+        default:
+            return -1;
+    }
+
+    if (handle != INVALID_HANDLE && CopyBuffer(handle, 0, shift, 1, buffer) > 0) {
+        results[0] = buffer[0];
+        IndicatorRelease(handle);
+        return 1;
+    }
+    if (handle != INVALID_HANDLE) IndicatorRelease(handle);
+    return -1;
+}
+
+bool IsValidTradeOperation(int orderType) { return (orderType >= 0 && orderType <= 5); }
+
+ENUM_ORDER_TYPE ConvertOrderType(int mql4OrderType) {
+    switch(mql4OrderType) {
+        case 0: return ORDER_TYPE_BUY;
+        case 1: return ORDER_TYPE_SELL;
+        case 2: return ORDER_TYPE_BUY_LIMIT;
+        case 3: return ORDER_TYPE_SELL_LIMIT;
+        case 4: return ORDER_TYPE_BUY_STOP;
+        case 5: return ORDER_TYPE_SELL_STOP;
+        default: return ORDER_TYPE_BUY;
+    }
+}
+
+double DefaultOpenPrice(string symbol, ENUM_ORDER_TYPE orderType) {
+    return NormalizePrice(symbol, (orderType == ORDER_TYPE_BUY || orderType == ORDER_TYPE_BUY_LIMIT || orderType == ORDER_TYPE_BUY_STOP) ?
+            SymbolInfoDouble(symbol, SYMBOL_ASK) : SymbolInfoDouble(symbol, SYMBOL_BID));
+}
+
+double NormalizePrice(string symbol, double price) {
+    if (price == 0) return 0;
+    double tickSize = SymbolInfoDouble(symbol, SYMBOL_TRADE_TICK_SIZE);
+    return MathRound(price / tickSize) * tickSize;
+}
+
+int DefaultSlippage(string symbol) {
+    double tickSize = SymbolInfoDouble(symbol, SYMBOL_TRADE_TICK_SIZE);
+    double spread = MathAbs(SymbolInfoDouble(symbol, SYMBOL_ASK) - SymbolInfoDouble(symbol, SYMBOL_BID));
+    return (int)(2.0 * spread / tickSize);
+}
+
+double NormalizeLots(string symbol, double lots) {
+    double lotStep = SymbolInfoDouble(symbol, SYMBOL_VOLUME_STEP);
+    double minLot = SymbolInfoDouble(symbol, SYMBOL_VOLUME_MIN);
+    return MathMax(MathRound(lots / lotStep) * lotStep, minLot);
+}
+
+double CalculateSL(string symbol, ENUM_ORDER_TYPE orderType, double price, int points) {
+    double point = SymbolInfoDouble(symbol, SYMBOL_POINT);
+    return (orderType == ORDER_TYPE_BUY || orderType == ORDER_TYPE_BUY_LIMIT || orderType == ORDER_TYPE_BUY_STOP) ?
+           price - points * point : price + points * point;
+}
+
+double CalculateTP(string symbol, ENUM_ORDER_TYPE orderType, double price, int points) {
+    double point = SymbolInfoDouble(symbol, SYMBOL_POINT);
+    return (orderType == ORDER_TYPE_BUY || orderType == ORDER_TYPE_BUY_LIMIT || orderType == ORDER_TYPE_BUY_STOP) ?
+           price + points * point : price - points * point;
+}
+
+string CustomErrorDescription(int errorCode) {
+    switch(errorCode) {
+        case 0: return "Success";
+        case 4001: return "Wrong function pointer";
+        case 4002: return "Array index out of range";
+        case 4066: return "History data updating";
+        default: return "Error " + IntegerToString(errorCode);
+    }
+}
+
+template<typename T> T StringToEnum(string str, T enumType) {
+    for (int i = 0; i < 256; i++) {
+        if (str == EnumToString(enumType = (T)i)) return enumType;
+    }
+    return (T)-1;
+}
+
+template <typename T, typename E> bool ArrayEraseElement(T& arr[], E element) {
+    for (int i = 0; i < ArraySize(arr); ++i) {
+        if (arr[i] == element) {
+            for(int j = i; j < ArraySize(arr) - 1; ++j) arr[j] = arr[j + 1];
+            ArrayResize(arr, ArraySize(arr) - 1);
+            return true;
+        }
+    }
+    return false;
+}
+
+void Trace(string msg) { if (VERBOSE) Print(msg); }
+
+bool IsNullOrMissing(CJAVal& obj, string key) {
+    return !obj.HasKey(key) || obj[key].m_type == jtNULL;
+}
+
+bool GetDefault(CJAVal& obj, string key, bool defaultVal) {
+    return IsNullOrMissing(obj, key) ? defaultVal : obj[key].ToBool();
+}
+
+int GetDefault(CJAVal& obj, string key, int defaultVal) {
+    return IsNullOrMissing(obj, key) ? defaultVal : (int)obj[key].ToInt();
+}
+
+long GetDefault(CJAVal& obj, string key, long defaultVal) {
+    return IsNullOrMissing(obj, key) ? defaultVal : obj[key].ToInt();
+}
+
+double GetDefault(CJAVal& obj, string key, double defaultVal) {
+    return IsNullOrMissing(obj, key) ? defaultVal : obj[key].ToDbl();
+}
+
+string GetDefault(CJAVal& obj, string key, string defaultVal) {
+    return IsNullOrMissing(obj, key) ? defaultVal : obj[key].ToStr();
+}
+//+------------------------------------------------------------------+

--- a/metatrader5/MQL5/Include/JAson.mqh
+++ b/metatrader5/MQL5/Include/JAson.mqh
@@ -1,0 +1,350 @@
+//+------------------------------------------------------------------ß
+//|                                                            JAson |
+//|    This software is licensed under the MIT https://goo.gl/eyJgHe |
+//+------------------------------------------------------------------+
+#property copyright "Copyright © 2006-2017"
+#property version "1.12"
+#property strict
+
+//------------------------------------------------------------------	enum enJAType
+enum enJAType { jtUNDEF, jtNULL, jtBOOL, jtINT, jtDBL, jtSTR, jtARRAY, jtOBJ };
+
+//------------------------------------------------------------------	class CJAVal
+class CJAVal
+{
+public:
+	virtual void Clear(enJAType jt=jtUNDEF, bool savekey=false) { m_parent=NULL; if (!savekey) m_key=""; m_type=jt; m_bv=false; m_iv=0; m_dv=0; m_prec=8; m_sv=""; ArrayResize(m_e, 0, 100); }
+	virtual bool Copy(const CJAVal &a) { m_key=a.m_key; CopyData(a); return true; }
+	virtual void CopyData(const CJAVal& a) { m_type=a.m_type; m_bv=a.m_bv; m_iv=a.m_iv; m_dv=a.m_dv; m_prec=a.m_prec; m_sv=a.m_sv; CopyArr(a); }
+	virtual void CopyArr(const CJAVal& a) { int n=ArrayResize(m_e, ArraySize(a.m_e)); for (int i=0; i<n; i++) { m_e[i]=a.m_e[i]; m_e[i].m_parent=GetPointer(this); } }
+	
+public:
+	CJAVal m_e[];
+	string m_key;
+	string m_lkey;
+	CJAVal* m_parent;
+	enJAType m_type;
+	bool m_bv;
+	long m_iv;
+	double m_dv; int m_prec;
+	string m_sv;
+	static int code_page;
+	
+public:
+	CJAVal() { Clear(); }
+	CJAVal(CJAVal* aparent, enJAType atype) { Clear(); m_type=atype; m_parent=aparent; }
+	CJAVal(enJAType t, string a) { Clear(); FromStr(t, a); }
+	CJAVal(const int a) { Clear(); m_type=jtINT; m_iv=a; m_dv=(double)m_iv; m_sv=IntegerToString(m_iv); m_bv=m_iv!=0; }
+	CJAVal(const long a) { Clear(); m_type=jtINT; m_iv=a; m_dv=(double)m_iv; m_sv=IntegerToString(m_iv); m_bv=m_iv!=0; }
+	CJAVal(const double a, int aprec=-100) { Clear(); m_type=jtDBL; m_dv=a; if (aprec>-100) m_prec=aprec; m_iv=(long)m_dv; m_sv=DoubleToString(m_dv, m_prec); m_bv=m_iv!=0; }
+	CJAVal(const bool a) { Clear(); m_type=jtBOOL; m_bv=a; m_iv=m_bv; m_dv=m_bv; m_sv=IntegerToString(m_iv); }
+	CJAVal(const CJAVal& a) { Clear(); Copy(a); }
+	~CJAVal() { Clear(); }
+	
+public:
+	int Size() { return ArraySize(m_e); }
+	virtual bool IsNumeric() { return m_type==jtDBL || m_type==jtINT; }
+	virtual CJAVal* FindKey(string akey) { for (int i=Size()-1; i>=0; --i) if (m_e[i].m_key==akey) return GetPointer(m_e[i]); return NULL; }
+	virtual CJAVal* HasKey(string akey, enJAType atype=jtUNDEF) { CJAVal* e=FindKey(akey); if (CheckPointer(e)!=POINTER_INVALID) { if (atype==jtUNDEF || atype==e.m_type) return GetPointer(e); } return NULL; }
+	virtual CJAVal* operator[](string akey);
+	virtual CJAVal* operator[](int i);
+	void operator=(const CJAVal &a) { Copy(a); }
+	void operator=(const int a) { m_type=jtINT; m_iv=a; m_dv=(double)m_iv; m_bv=m_iv!=0; }
+	void operator=(const long a) { m_type=jtINT; m_iv=a; m_dv=(double)m_iv; m_bv=m_iv!=0; }
+	void operator=(const double a) { m_type=jtDBL; m_dv=a; m_iv=(long)m_dv; m_bv=m_iv!=0; }
+	void operator=(const bool a) { m_type=jtBOOL; m_bv=a; m_iv=(long)m_bv; m_dv=(double)m_bv; }
+	void operator=(string a) { m_type=(a!=NULL)?jtSTR:jtNULL; m_sv=a; m_iv=StringToInteger(m_sv); m_dv=StringToDouble(m_sv); m_bv=a!=NULL; }
+
+	bool operator==(const int a) { return m_iv==a; }
+	bool operator==(const long a) { return m_iv==a; }
+	bool operator==(const double a) { return m_dv==a; }
+	bool operator==(const bool a) { return m_bv==a; }
+	bool operator==(string a) { return m_sv==a; }
+	
+	bool operator!=(const int a) { return m_iv!=a; }
+	bool operator!=(const long a) { return m_iv!=a; }
+	bool operator!=(const double a) { return m_dv!=a; }
+	bool operator!=(const bool a) { return m_bv!=a; }
+	bool operator!=(string a) { return m_sv!=a; }
+
+	long ToInt() const { return m_iv; }
+	double ToDbl() const { return m_dv; }
+	bool ToBool() const { return m_bv; }
+	string ToStr() { return m_sv; }
+
+	virtual void FromStr(enJAType t, string a)
+	{
+		m_type=t;
+		switch (m_type)
+		{
+		case jtBOOL: m_bv=(StringToInteger(a)!=0); m_iv=(long)m_bv; m_dv=(double)m_bv; m_sv=a; break;
+		case jtINT: m_iv=StringToInteger(a); m_dv=(double)m_iv; m_sv=a; m_bv=m_iv!=0; break;
+		case jtDBL: m_dv=StringToDouble(a); m_iv=(long)m_dv; m_sv=a; m_bv=m_iv!=0; break;
+		case jtSTR: m_sv=Unescape(a); m_type=(m_sv!=NULL)?jtSTR:jtNULL; m_iv=StringToInteger(m_sv); m_dv=StringToDouble(m_sv); m_bv=m_sv!=NULL; break;
+		}
+	}
+	virtual string GetStr(char& js[], int i, int slen) { if (slen==0) return ""; char cc[]; ArrayCopy(cc, js, 0, i, slen); return CharArrayToString(cc, 0, WHOLE_ARRAY, CJAVal::code_page); }
+
+	virtual void Set(const CJAVal& a) { if (m_type==jtUNDEF) m_type=jtOBJ; CopyData(a); }
+	virtual void Set(const CJAVal& list[]);
+	virtual CJAVal* Add(const CJAVal& item) { if (m_type==jtUNDEF) m_type=jtARRAY; /*ASSERT(m_type==jtOBJ || m_type==jtARRAY);*/ return AddBase(item); } // добавление
+	virtual CJAVal* Add(const int a) { CJAVal item(a); return Add(item); }
+	virtual CJAVal* Add(const long a) { CJAVal item(a); return Add(item); }
+	virtual CJAVal* Add(const double a, int aprec=-2) { CJAVal item(a, aprec); return Add(item); }
+	virtual CJAVal* Add(const bool a) { CJAVal item(a); return Add(item); }
+	virtual CJAVal* Add(string a) { CJAVal item(jtSTR, a); return Add(item); }
+	virtual CJAVal* AddBase(const CJAVal &item) { int c=Size(); ArrayResize(m_e, c+1, 100); m_e[c]=item; m_e[c].m_parent=GetPointer(this); return GetPointer(m_e[c]); } // добавление
+	virtual CJAVal* New() { if (m_type==jtUNDEF) m_type=jtARRAY; /*ASSERT(m_type==jtOBJ || m_type==jtARRAY);*/ return NewBase(); } // добавление
+	virtual CJAVal* NewBase() { int c=Size(); ArrayResize(m_e, c+1, 100); return GetPointer(m_e[c]); } // добавление
+
+	virtual string Escape(string a);
+	virtual string Unescape(string a);
+public:
+	virtual void Serialize(string &js, bool bf=false, bool bcoma=false);
+	virtual string Serialize() { string js; Serialize(js); return js; }
+	virtual bool Deserialize(char& js[], int slen, int &i);
+	virtual bool ExtrStr(char& js[], int slen, int &i);
+	virtual bool Deserialize(string js, int acp=CP_ACP) { int i=0; Clear(); CJAVal::code_page=acp; char arr[]; int slen=StringToCharArray(js, arr, 0, WHOLE_ARRAY, CJAVal::code_page); return Deserialize(arr, slen, i); }
+	virtual bool Deserialize(char& js[], int acp=CP_ACP) { int i=0; Clear(); CJAVal::code_page=acp; return Deserialize(js, ArraySize(js), i); }
+};
+
+int CJAVal::code_page=CP_ACP;
+
+//------------------------------------------------------------------	operator[]
+CJAVal* CJAVal::operator[](string akey) { if (m_type==jtUNDEF) m_type=jtOBJ; CJAVal* v=FindKey(akey); if (v) return v; CJAVal b(GetPointer(this), jtUNDEF); b.m_key=akey; v=Add(b); return v; }
+//------------------------------------------------------------------	operator[]
+CJAVal* CJAVal::operator[](int i)
+{
+	if (m_type==jtUNDEF) m_type=jtARRAY;
+	while (i>=Size()) { CJAVal b(GetPointer(this), jtUNDEF); if (CheckPointer(Add(b))==POINTER_INVALID) return NULL; }
+	return GetPointer(m_e[i]);
+}
+//------------------------------------------------------------------	Set
+void CJAVal::Set(const CJAVal& list[])
+{
+	if (m_type==jtUNDEF) m_type=jtARRAY;
+	int n=ArrayResize(m_e, ArraySize(list), 100); for (int i=0; i<n; ++i) { m_e[i]=list[i]; m_e[i].m_parent=GetPointer(this); }
+}
+
+//------------------------------------------------------------------	Serialize
+void CJAVal::Serialize(string& js, bool bkey/*=false*/, bool coma/*=false*/)
+{
+	if (m_type==jtUNDEF) return;
+	if (coma) js+=",";
+	if (bkey) js+=StringFormat("\"%s\":", m_key);
+	int _n=Size();
+	switch (m_type)
+	{
+	case jtNULL: js+="null"; break;
+	case jtBOOL: js+=(m_bv?"true":"false"); break;
+	case jtINT: js+=IntegerToString(m_iv); break;
+	case jtDBL: js+=DoubleToString(m_dv, m_prec); break;
+	case jtSTR: { string ss=Escape(m_sv); if (StringLen(ss)>0) js+=StringFormat("\"%s\"", ss); else js+="null"; } break;
+	case jtARRAY: js+="["; for (int i=0; i<_n; i++) m_e[i].Serialize(js, false, i>0); js+="]"; break;
+	case jtOBJ: js+="{"; for (int i=0; i<_n; i++) m_e[i].Serialize(js, true, i>0); js+="}"; break;
+	}
+}
+
+//------------------------------------------------------------------	Deserialize
+bool CJAVal::Deserialize(char& js[], int slen, int &i)
+{
+	string num="0123456789+-.eE";
+	int i0=i;
+	for (; i<slen; i++)
+	{
+		char c=js[i]; if (c==0) break;
+		switch (c)
+		{
+		case '\t': case '\r': case '\n': case ' ': // пропускаем из имени пробелы
+			i0=i+1; break;
+
+		case '[': // начало массива. создаём объекты и забираем из js
+		{
+			i0=i+1;
+			if (m_type!=jtUNDEF) { Print(m_key+" "+string(__LINE__)); return false; } // если значение уже имеет тип, то это ошибка
+			m_type=jtARRAY; // задали тип значения
+			i++; CJAVal val(GetPointer(this), jtUNDEF);
+			while (val.Deserialize(js, slen, i))
+			{
+				if (val.m_type!=jtUNDEF) Add(val);
+				if (val.m_type==jtINT || val.m_type==jtDBL || val.m_type==jtARRAY) i++;
+				val.Clear(); val.m_parent=GetPointer(this);
+				if (js[i]==']') break;
+				i++; if (i>=slen) { Print(m_key+" "+string(__LINE__)); return false; }
+			}
+			return js[i]==']' || js[i]==0;
+		}
+		break;
+		case ']': if (!m_parent) return false; return m_parent.m_type==jtARRAY; // конец массива, текущее значение должны быть массивом
+
+		case ':':
+		{
+			if (m_lkey=="") { Print(m_key+" "+string(__LINE__)); return false; }
+			CJAVal val(GetPointer(this), jtUNDEF);
+			CJAVal *oc=Add(val); // тип объекта пока не определён
+			oc.m_key=m_lkey; m_lkey=""; // задали имя ключа
+			i++; if (!oc.Deserialize(js, slen, i)) { Print(m_key+" "+string(__LINE__)); return false; }
+			break;
+		}
+		case ',': // разделитель значений // тип значения уже должен быть определён
+			i0=i+1;
+			if (!m_parent && m_type!=jtOBJ) { Print(m_key+" "+string(__LINE__)); return false; }
+			else if (m_parent)
+			{
+				if (m_parent.m_type!=jtARRAY && m_parent.m_type!=jtOBJ) { Print(m_key+" "+string(__LINE__)); return false; }
+				if (m_parent.m_type==jtARRAY && m_type==jtUNDEF) return true;
+			}
+			break;
+
+			// примитивы могут быть ТОЛЬКО в массиве / либо самостоятельно
+		case '{': // начало объекта. создаем объект и забираем его из js
+			i0=i+1;
+			if (m_type!=jtUNDEF) { Print(m_key+" "+string(__LINE__)); return false; }// ошибка типа
+			m_type=jtOBJ; // задали тип значения
+			i++; if (!Deserialize(js, slen, i)) { Print(m_key+" "+string(__LINE__)); return false; } // вытягиваем его
+			return js[i]=='}' || js[i]==0;
+			break;
+		case '}': return m_type==jtOBJ; // конец объекта, текущее значение должно быть объектом
+
+		case 't': case 'T': // начало true
+		case 'f': case 'F': // начало false
+			if (m_type!=jtUNDEF) { Print(m_key+" "+string(__LINE__)); return false; } // ошибка типа
+			m_type=jtBOOL; // задали тип значения
+			if (i+3<slen) { if (StringCompare(GetStr(js, i, 4), "true", false)==0) { m_bv=true; i+=3; return true; } }
+			if (i+4<slen) { if (StringCompare(GetStr(js, i, 5), "false", false)==0) { m_bv=false; i+=4; return true; } }
+			Print(m_key+" "+string(__LINE__)); return false; // не тот тип или конец строки
+			break;
+		case 'n': case 'N': // начало null
+			if (m_type!=jtUNDEF) { Print(m_key+" "+string(__LINE__)); return false; } // ошибка типа
+			m_type=jtNULL; // задали тип значения
+			if (i+3<slen) if (StringCompare(GetStr(js, i, 4), "null", false)==0) { i+=3; return true; }
+			Print(m_key+" "+string(__LINE__)); return false; // не NULL или конец строки
+			break;
+
+		case '0': case '1': case '2': case '3': case '4': case '5': case '6': case '7': case '8': case '9': case '-': case '+': case '.': // начало числа
+		{
+			if (m_type!=jtUNDEF) { Print(m_key+" "+string(__LINE__)); return false; } // ошибка типа
+			bool dbl=false;// задали тип значения
+			int is=i; while (js[i]!=0 && i<slen) { i++; if (StringFind(num, GetStr(js, i, 1))<0) break; if (!dbl) dbl=(js[i]=='.' || js[i]=='e' || js[i]=='E'); }
+			m_sv=GetStr(js, is, i-is);
+			if (dbl) { m_type=jtDBL; m_dv=StringToDouble(m_sv); m_iv=(long)m_dv; m_bv=m_iv!=0; }
+			else { m_type=jtINT; m_iv=StringToInteger(m_sv); m_dv=(double)m_iv; m_bv=m_iv!=0; } // уточнии тип значения
+			i--; return true; // отодвинулись на 1 символ назад и вышли
+			break;
+		}
+		case '\"': // начало или конец строки
+			if (m_type==jtOBJ) // если тип еще неопределён и ключ не задан
+			{
+				i++; int is=i; if (!ExtrStr(js, slen, i)) { Print(m_key+" "+string(__LINE__)); return false; } // это ключ, идём до конца строки
+				m_lkey=GetStr(js, is, i-is);
+			}
+			else
+			{
+				if (m_type!=jtUNDEF) { Print(m_key+" "+string(__LINE__)); return false; } // ошибка типа
+				m_type=jtSTR; // задали тип значения
+				i++; int is=i;
+				if (!ExtrStr(js, slen, i)) { Print(m_key+" "+string(__LINE__)); return false; }
+				FromStr(jtSTR, GetStr(js, is, i-is));
+				return true;
+			}
+			break;
+		}
+	}
+	return true;
+}
+
+//------------------------------------------------------------------	ExtrStr
+bool CJAVal::ExtrStr(char& js[], int slen, int &i)
+{
+	for (; js[i]!=0 && i<slen; i++)
+	{
+		char c=js[i];
+		if (c=='\"') break; // конец строки
+		if (c=='\\' && i+1<slen)
+		{
+			i++; c=js[i];
+			switch (c)
+			{
+			case '/': case '\\': case '\"': case 'b': case 'f': case 'r': case 'n': case 't': break; // это разрешенные
+			case 'u': // \uXXXX
+			{
+				i++;
+				for (int j=0; j<4 && i<slen && js[i]!=0; j++, i++)
+				{
+					if (!((js[i]>='0' && js[i]<='9') || (js[i]>='A' && js[i]<='F') || (js[i]>='a' && js[i]<='f'))) { Print(m_key+" "+CharToString(js[i])+" "+string(__LINE__)); return false; } // не hex
+				}
+				i--;
+				break;
+			}
+			default: break; /*{ return false; } // неразрешенный символ с экранированием */
+			}
+		}
+	}
+	return true;
+}
+//------------------------------------------------------------------	Escape
+string CJAVal::Escape(string a)
+{
+	ushort as[], s[]; int n=StringToShortArray(a, as); if (ArrayResize(s, 2*n)!=2*n) return NULL;
+	int j=0;
+	for (int i=0; i<n; i++)
+	{
+		switch (as[i])
+		{
+		case '\\': s[j]='\\'; j++; s[j]='\\'; j++; break;
+		case '"': s[j]='\\'; j++; s[j]='"'; j++; break;
+		case '/': s[j]='\\'; j++; s[j]='/'; j++; break;
+		case 8: s[j]='\\'; j++; s[j]='b'; j++; break;
+		case 12: s[j]='\\'; j++; s[j]='f'; j++; break;
+		case '\n': s[j]='\\'; j++; s[j]='n'; j++; break;
+		case '\r': s[j]='\\'; j++; s[j]='r'; j++; break;
+		case '\t': s[j]='\\'; j++; s[j]='t'; j++; break;
+		default: s[j]=as[i]; j++; break;
+		}
+	}
+	a=ShortArrayToString(s, 0, j);
+	return a;
+}
+//------------------------------------------------------------------	Unescape
+string CJAVal::Unescape(string a)
+{
+	ushort as[], s[]; int n=StringToShortArray(a, as); if (ArrayResize(s, n)!=n) return NULL;
+	int j=0, i=0;
+	while (i<n)
+	{
+		ushort c=as[i];
+		if (c=='\\' && i<n-1)
+		{
+			switch (as[i+1])
+			{
+			case '\\': c='\\'; i++; break;
+			case '"': c='"'; i++; break;
+			case '/': c='/'; i++; break;
+			case 'b': c=8; /*08='\b'*/; i++; break;
+			case 'f': c=12;/*0c=\f*/ i++; break;
+			case 'n': c='\n'; i++; break;
+			case 'r': c='\r'; i++; break;
+			case 't': c='\t'; i++; break;
+			case 'u': // \uXXXX
+			{
+				i+=2; ushort k=0;
+				for (int jj=0; jj<4 && i<n; jj++, i++)
+				{
+					c=as[i]; ushort h=0;
+					if (c>='0' && c<='9') h=c-'0';
+					else if (c>='A' && c<='F') h=c-'A'+10;
+					else if (c>='a' && c<='f') h=c-'a'+10;
+					else break; // не hex
+					k+=h*(ushort)pow(16, (3-jj));
+				}
+				i--;
+				c=k;
+				break;
+			}
+			}
+		}
+		s[j]=c; j++; i++;
+	}
+	a=ShortArrayToString(s, 0, j);
+	return a;
+}

--- a/metatrader5/MQL5/Include/README.md
+++ b/metatrader5/MQL5/Include/README.md
@@ -1,0 +1,50 @@
+# JAson.mqh
+JSON serialization and deserialization (native MQL) for MetaTrader 4/5.
+
+## Description
+This code is ported from a high-speed С++ library.  It was [originally posted](https://www.mql5.com/en/code/13663) on the MetaTrader code forums.
+
+## Examples
+```mql4
+string in, out;
+CJAVal js(NULL, jtUNDEF); bool b;
+
+//---
+Print("JASon Example Deserialization:");
+
+in="{\"a\":[1,2]}"; out=""; // example of input data
+b=js.Deserialize(in); // deserialized
+js.Serialize(out); // serialized again
+Print(in+" -> "+out); // output for comparison
+
+//---
+Print("JASon Example Serialization:");
+
+js["Test"]=1.4; // input data example
+out=""; js.Serialize(out); // serialized
+Print(out); // output
+```
+
+Authorization on a website and parsing the response:
+```mql4
+CJAVal jv;
+jv["login"]="Login"; // login
+jv["password"]="Pass"; // password
+
+//--- serialize to string  {"login":"Login","password":"Pass"}
+char data[]; 
+ArrayResize(data, StringToCharArray(jv.Serialize(), data, 0, WHOLE_ARRAY)-1);
+
+//--- send data
+char res_data[];
+string res_headers=NULL;
+int r=WebRequest("POST", "http://my.site.com/Authorize", "Content-Type: text/plain\r\n", 5000, data, res_data, res_headers);
+
+//--- assume the answer {"accessToken":"ABRAKADABRA","session_id":124521}
+//--- get AccessToken
+jv.Deserialize(res_data);
+string AccessToken=jv["accessToken"].ToStr();
+```
+
+## Author
+[sergeev](https://www.mql5.com/en/users/sergeev)


### PR DESCRIPTION
- Add ZeroMQ_Server_EA.mq5 for MT5
- Add ZeroMQ_Monitor_EA.mq5 watchdog with auto-restart
- Add detailed setup documentation for MT5
- Update main README with MT5 installation instructions
- Update mql-zmq submodule to fix/mql5_compatibility branch

MT5 Features:
- Expert Advisor instead of script (supports templates)
- Watchdog monitor for automatic server restart
- Long (64-bit) ticket number support
- ENABLED parameter to disable monitor without removing

🤖 Generated with [Claude Code](https://claude.com/claude-code)